### PR TITLE
Fix #7 Starting zookeeper in cluster mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+java_path: /usr/local/openjdk/jdk-{{ openjdk_ver.major }}.{{ openjdk_ver.minor }}.{{ openjdk_ver.patch }}+{{ openjdk_ver.b }}-jre/openjdk.env
 zookeeper_tick_time: 2000
 zookeeper_init_limit: 10
 zookeeper_sync_limit: 5

--- a/templates/zookeeper.service.j2
+++ b/templates/zookeeper.service.j2
@@ -6,8 +6,7 @@ After=network.target
 
 [Service]
 Type=simple
-EnvironmentFile=-/usr/local/java/java-oracle.env
-EnvironmentFile=-/usr/local/java/oracle-jre.env
+EnvironmentFile=-{{java_path}}
 ExecStart={{zookeeper_dir}}/bin/zkServer.sh start-foreground
 Restart=on-failure
 


### PR DESCRIPTION
To solve the problem with running zookeeper in cluster mode, the proposed solution worked. In templates/zookeeper.service.j2 changed the value of EnvironmentFile to a variable that is defined in defaults/main.yml.